### PR TITLE
Fix sb exec start

### DIFF
--- a/cmd/push.go
+++ b/cmd/push.go
@@ -70,7 +70,7 @@ var pushCmd = &cobra.Command{
 				}
 
 				if uberJarFile != "" {
-					args := []string{"cp", uberJarFile, podName + ":/deployments", "-c", containerName}
+					args := []string{"cp", uberJarFile, podName + ":/deployments/app.jar", "-c", containerName}
 					log.Infof("Copy cmd : %s", args)
 					oc.ExecCommand(oc.Command{Args: args})
 				} else {

--- a/pkg/buildpack/deploymentconfig.go
+++ b/pkg/buildpack/deploymentconfig.go
@@ -140,7 +140,7 @@ func javaDeploymentConfig(application types.Application) *appsv1.DeploymentConfi
 								},
 								{
 									Name:  "JAVA_APP_JAR",
-									Value: application.Name + "-" + application.Version + ".jar",
+									Value: "app.jar",
 								},
 								{
 									Name:  "JAVA_DEBUG",


### PR DESCRIPTION
It's done by always using app.jar as the artifact that is used by the
s2i scripts