### PR TITLE
Custom application name is used (-a) is only needed in sb init

### DIFF
--- a/pkg/buildpack/deploymentconfig.go
+++ b/pkg/buildpack/deploymentconfig.go
@@ -17,6 +17,9 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+const OdoLabelName = "io.openshift.odo"
+const OdoLabelValue = "inject-supervisord"
+
 func CreatePVC(clientset *kubernetes.Clientset, application types.Application, size string) {
 	if !oc.Exists("pvc", pvcName) {
 		quantity, err := resource.ParseQuantity(size)
@@ -103,8 +106,8 @@ func javaDeploymentConfig(application types.Application, commands string) *appsv
 		ObjectMeta: metav1.ObjectMeta{
 			Name: application.Name,
 			Labels: map[string]string{
-				"app":              application.Name,
-				"io.openshift.odo": "inject-supervisord",
+				"app":        application.Name,
+				OdoLabelName: OdoLabelValue,
 			},
 		},
 		Spec: appsv1.DeploymentConfigSpec{
@@ -222,10 +225,10 @@ func populateEnvVar(application types.Application) []corev1.EnvVar {
 
 	// Add default values
 	envs = append(envs,
-		corev1.EnvVar{Name:  "JAVA_APP_DIR", Value: "/deployments",},
-		corev1.EnvVar{Name:  "JAVA_APP_JAR", Value: "app.jar",},
-		corev1.EnvVar{Name:  "JAVA_DEBUG", Value: "true",},
-		corev1.EnvVar{Name:  "JAVA_DEBUG_PORT", Value: "5005",})
+		corev1.EnvVar{Name: "JAVA_APP_DIR", Value: "/deployments"},
+		corev1.EnvVar{Name: "JAVA_APP_JAR", Value: "app.jar"},
+		corev1.EnvVar{Name: "JAVA_DEBUG", Value: "true"},
+		corev1.EnvVar{Name: "JAVA_DEBUG_PORT", Value: "5005"})
 
 	return envs
 }

--- a/pkg/buildpack/manifest.go
+++ b/pkg/buildpack/manifest.go
@@ -8,10 +8,9 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/snowdrop/k8s-supervisor/pkg/buildpack/types"
 	"os"
-	"path"
 )
 
-func ParseManifest(manifestPath string, appName string) types.Application {
+func ParseManifest(manifestPath string) types.Application {
 	log.Debugf("Parsing Application Config at %s", manifestPath)
 
 	// Create an Application with default values
@@ -32,18 +31,7 @@ func ParseManifest(manifestPath string, appName string) types.Application {
 		log.Infof("No MANIFEST file detected, using default values")
 	}
 
-	// if we specified an application name, use it and override any set value
-	if len(appName) > 0 {
-		appConfig.Name = appName
-	} else {
-		if len(appConfig.Name) == 0 {
-			// we need to set an application name, use the current directory name as default
-			dir, _ := path.Split(manifestPath)
-			appConfig.Name = path.Base(dir)
-		}
-	}
-
-	log.Infof("Application '%s' configured", appConfig.Name)
+	log.Infof("Application configured")
 
 	if log.GetLevel() == log.DebugLevel {
 		log.Debug("Application's config")

--- a/pkg/common/oc/execute.go
+++ b/pkg/common/oc/execute.go
@@ -57,3 +57,14 @@ func Exists(kind string, name string) bool {
 		return name == s
 	}
 }
+
+func GetNamesByLabel(kind string, labelName string, labelValue string) []string {
+	s, err := ExecCommandAndReturn(Command{Args: []string{"get", kind, "-l", labelName + "=" + labelValue, "-o", "jsonpath={.items[*].metadata.name}"}})
+	if err != nil {
+		panic(err)
+	} else if len(s) == 0 {
+		return make([]string, 0)
+	} else {
+		return strings.Fields(s)
+	}
+}


### PR DESCRIPTION
This works by making the application search for the matching DC when
no application name is specified. That way each subsequent to init
command, will locate the DC and use it instead of waiting for the pod
of a DC that will be never come into existence

Fixes: #27